### PR TITLE
Fix #23: Allow Valiant bees to sometimes drop from hives

### DIFF
--- a/src/main/java/magicbees/block/types/HiveType.java
+++ b/src/main/java/magicbees/block/types/HiveType.java
@@ -127,14 +127,16 @@ public enum HiveType
 		ArrayList<ItemStack> hiveDrops = new ArrayList<ItemStack>();
 		int dart;
 		
+		Collections.shuffle(this.drops);
+
 		// Get a princess.
 		int throttle = 0;
 		while (hiveDrops.size() <= 0 && throttle < 10)
 		{
 			++throttle;
-			dart = world.rand.nextInt(100);
 			for (IHiveDrop drop : drops)
 			{
+				dart = world.rand.nextInt(100);
 				if (dart <= drop.getChance(world, x, y, z))
 				{
 					hiveDrops.add(drop.getPrincess(world, x, y, z, fortune));
@@ -144,9 +146,9 @@ public enum HiveType
 		}
 		
 		// Get a drone, maybe.
-		dart = world.rand.nextInt(100);
 		for (IHiveDrop drop : drops)
 		{
+			dart = world.rand.nextInt(100);
 			if (dart <= drop.getChance(world, x, y, z))
 			{
 				hiveDrops.addAll(drop.getDrones(world, x, y, z, fortune));
@@ -155,9 +157,9 @@ public enum HiveType
 		}
 		
 		// Get additional drops.
-		dart = world.rand.nextInt(100);
 		for (IHiveDrop drop : drops)
 		{
+			dart = world.rand.nextInt(100);
 			if (dart <= drop.getChance(world, x, y, z))
 			{
 				hiveDrops.addAll(drop.getAdditional(world, x, y, z, fortune));


### PR DESCRIPTION
Fixes #23 by making the Magic Bees code act the same as the Forestry and Extra Bees code: the hive droplist is shuffled before making a random selection (so any bee *could* be at the front of the list and be attempted first), and the random number is chosen *inside* the `for` loop rather than outside so that each bee's chance of being chosen is independent.