### PR TITLE
Fix nodes growing without limit

### DIFF
--- a/src/main/java/magicbees/main/utils/compat/thaumcraft/NodeHelper.java
+++ b/src/main/java/magicbees/main/utils/compat/thaumcraft/NodeHelper.java
@@ -110,7 +110,7 @@ public class NodeHelper {
 							aspectToAdd = getWeightedRandomAspect(world.rand);
 							++rollAttempts;
 						}
-						while (aspectsBase.getAmount(aspectToAdd) < 255 && 20 < rollAttempts);
+						while (aspectsBase.getAmount(aspectToAdd) > 255 && rollAttempts < 20);
 						
 						if (20 <= rollAttempts) {
 							return false;


### PR DESCRIPTION
With this patch, aura node growth from Nexus bees will be properly capped at 256 points per aspect, as originally intended, instead of aspect nodes growing without any limit.

This will fix #32.